### PR TITLE
Support for typing indicator

### DIFF
--- a/MessageKit.xcodeproj/project.pbxproj
+++ b/MessageKit.xcodeproj/project.pbxproj
@@ -61,6 +61,8 @@
 		B7A03F781F866A30006AEF79 /* TestMessagesViewControllerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A03F761F866A30006AEF79 /* TestMessagesViewControllerModel.swift */; };
 		B7A03F791F866A30006AEF79 /* TestMessageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A03F771F866A30006AEF79 /* TestMessageModel.swift */; };
 		B7A03F7B1F866B85006AEF79 /* MessageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A03F7A1F866B85006AEF79 /* MessageCollectionViewCell.swift */; };
+		E42345A81F9E9733005DA7D3 /* TypingIndicatorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42345A71F9E9733005DA7D3 /* TypingIndicatorCell.swift */; };
+		E42A409B1F9E767A001B6197 /* TypingIndicatorDisplayDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E42A409A1F9E767A001B6197 /* TypingIndicatorDisplayDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -131,6 +133,8 @@
 		B7A03F761F866A30006AEF79 /* TestMessagesViewControllerModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMessagesViewControllerModel.swift; sourceTree = "<group>"; };
 		B7A03F771F866A30006AEF79 /* TestMessageModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMessageModel.swift; sourceTree = "<group>"; };
 		B7A03F7A1F866B85006AEF79 /* MessageCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCollectionViewCell.swift; sourceTree = "<group>"; };
+		E42345A71F9E9733005DA7D3 /* TypingIndicatorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingIndicatorCell.swift; sourceTree = "<group>"; };
+		E42A409A1F9E767A001B6197 /* TypingIndicatorDisplayDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypingIndicatorDisplayDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -159,6 +163,7 @@
 				B7A03F391F866946006AEF79 /* MediaMessageCell.swift */,
 				B7A03F7A1F866B85006AEF79 /* MessageCollectionViewCell.swift */,
 				B7A03F361F866946006AEF79 /* TextMessageCell.swift */,
+				E42345A71F9E9733005DA7D3 /* TypingIndicatorCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -298,6 +303,7 @@
 				B7A03F561F8669C9006AEF79 /* MessagesDisplayDelegate.swift */,
 				B7A03F541F8669C9006AEF79 /* MessagesLayoutDelegate.swift */,
 				B7A03F511F8669C9006AEF79 /* MessageType.swift */,
+				E42A409A1F9E767A001B6197 /* TypingIndicatorDisplayDelegate.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -456,6 +462,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E42345A81F9E9733005DA7D3 /* TypingIndicatorCell.swift in Sources */,
 				B7A03F2B1F866895006AEF79 /* AvatarHorizontalAlignment.swift in Sources */,
 				B7A03F3C1F866946006AEF79 /* LocationMessageCell.swift in Sources */,
 				B7A03F5B1F8669CA006AEF79 /* MessageType.swift in Sources */,
@@ -468,6 +475,7 @@
 				B7A03F4B1F86694F006AEF79 /* MessageContainerView.swift in Sources */,
 				B7A03F281F866895006AEF79 /* LocationMessageSnapshotOptions.swift in Sources */,
 				B7A03F5D1F8669CA006AEF79 /* LocationMessageDisplayDelegate.swift in Sources */,
+				E42A409B1F9E767A001B6197 /* TypingIndicatorDisplayDelegate.swift in Sources */,
 				B7A03F481F86694F006AEF79 /* InputTextView.swift in Sources */,
 				B7A03F6C1F8669EB006AEF79 /* UIView+Extensions.swift in Sources */,
 				B7A03F631F8669CA006AEF79 /* LocationMessageLayoutDelegate.swift in Sources */,

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -110,7 +110,6 @@ open class MessagesViewController: UIViewController {
     private func setupDelegates() {
         messagesCollectionView.delegate = self
         messagesCollectionView.dataSource = self
-        messagesCollectionView.typingIndicatorDelegate = self
     }
 
     private func registerReusableViews() {
@@ -314,7 +313,7 @@ extension MessagesViewController {
 }
 
 // MARK: Typing indicator
-extension MessagesViewController: TypingIndicatorDisplayDelegate {
+extension MessagesViewController {
     
     public func indexPathForTypingIndicator() -> IndexPath {
         
@@ -323,22 +322,6 @@ extension MessagesViewController: TypingIndicatorDisplayDelegate {
         }
         let numberOfMessages = messagesDataSource.numberOfMessages(in: messagesCollectionView)
         return IndexPath(item: 0, section: numberOfMessages)
-        
-    }
-    
-    open func viewForTypingIndicator() -> UIView {
-        
-        let typingIndicatorLabel = UILabel()
-        typingIndicatorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
-        typingIndicatorLabel.textColor = UIColor.black
-        typingIndicatorLabel.text = "someone is typing..."
-        return typingIndicatorLabel
-        
-    }
-    
-    open func frameForIndicatorView() -> CGRect {
-        
-        return CGRect(x: 5, y: 5, width: 325.0, height: 30.0)
         
     }
     

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -326,7 +326,7 @@ extension MessagesViewController: TypingIndicatorDisplayDelegate {
         
     }
     
-    public func viewForTypingIndicator() -> UIView {
+    open func viewForTypingIndicator() -> UIView {
         
         let typingIndicatorLabel = UILabel()
         typingIndicatorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
@@ -336,7 +336,7 @@ extension MessagesViewController: TypingIndicatorDisplayDelegate {
         
     }
     
-    public func frameForIndicatorView() -> CGRect {
+    open func frameForIndicatorView() -> CGRect {
         
         return CGRect(x: 5, y: 5, width: 325.0, height: 30.0)
         

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -42,6 +42,14 @@ open class MessagesViewController: UIViewController {
             messagesCollectionView.contentInset.top = inset
         }
     }
+    
+    open var showTypingIndicator = false {
+        didSet {
+            if oldValue != showTypingIndicator {
+                messagesCollectionView.reloadData()
+            }
+        }
+    }
 
     private var isFirstLayout: Bool = true
 
@@ -102,6 +110,7 @@ open class MessagesViewController: UIViewController {
     private func setupDelegates() {
         messagesCollectionView.delegate = self
         messagesCollectionView.dataSource = self
+        messagesCollectionView.typingIndicatorDelegate = self
     }
 
     private func registerReusableViews() {
@@ -109,6 +118,7 @@ open class MessagesViewController: UIViewController {
         messagesCollectionView.register(TextMessageCell.self)
         messagesCollectionView.register(MediaMessageCell.self)
         messagesCollectionView.register(LocationMessageCell.self)
+        messagesCollectionView.register(TypingIndicatorCell.self)
 
         messagesCollectionView.register(MessageFooterView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionFooter)
         messagesCollectionView.register(MessageHeaderView.self, forSupplementaryViewOfKind: UICollectionElementKindSectionHeader)
@@ -151,7 +161,8 @@ extension MessagesViewController: UICollectionViewDataSource {
         guard let collectionView = collectionView as? MessagesCollectionView else { return 0 }
 
         // Each message is its own section
-        return collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
+        let numberOfMessages = collectionView.messagesDataSource?.numberOfMessages(in: collectionView) ?? 0
+        return showTypingIndicator ? numberOfMessages + 1 : numberOfMessages
     }
 
     open func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -172,7 +183,16 @@ extension MessagesViewController: UICollectionViewDataSource {
         guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
             fatalError("MessagesDataSource has not been set.")
         }
-
+        
+        if indexPath == indexPathForTypingIndicator() {
+            guard let indicatorDelegate = messagesCollectionView.typingIndicatorDelegate else {
+                fatalError("Typing indicator delegate has not been set")
+            }
+            let cell = messagesCollectionView.dequeueReusableCell(TypingIndicatorCell.self, for: indexPath)
+            cell.configure(in: messagesCollectionView)
+            return cell
+        }
+        
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
 
         switch message.data {
@@ -223,8 +243,14 @@ extension MessagesViewController: UICollectionViewDataSource {
         guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return .zero }
         guard let messagesDataSource = messagesCollectionView.messagesDataSource else { return .zero }
         guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        
         // Could pose a problem if subclass behaviors allows more than one item per section
         let indexPath = IndexPath(item: 0, section: section)
+        
+        if indexPath == indexPathForTypingIndicator() {
+            return .zero
+        }
+        
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
         return messagesLayoutDelegate.headerViewSize(for: message, at: indexPath, in: messagesCollectionView)
     }
@@ -233,6 +259,11 @@ extension MessagesViewController: UICollectionViewDataSource {
         guard let messagesCollectionView = collectionView as? MessagesCollectionView else { return .zero }
         guard let messagesDataSource = messagesCollectionView.messagesDataSource else { return .zero }
         guard let messagesLayoutDelegate = messagesCollectionView.messagesLayoutDelegate else { return .zero }
+        
+        if section == indexPathForTypingIndicator().section {
+            return .zero
+        }
+        
         // Could pose a problem if subclass behaviors allows more than one item per section
         let indexPath = IndexPath(item: 0, section: section)
         let message = messagesDataSource.messageForItem(at: indexPath, in: messagesCollectionView)
@@ -277,6 +308,21 @@ extension MessagesViewController {
             messagesCollectionView.contentInset.bottom = bottomInset
             messagesCollectionView.scrollIndicatorInsets.bottom = bottomInset
         }
+        
+    }
+    
+}
+
+// MARK: Typing indicator
+extension MessagesViewController: TypingIndicatorDisplayDelegate {
+    
+    public func indexPathForTypingIndicator() -> IndexPath {
+        
+        guard let messagesDataSource = messagesCollectionView.messagesDataSource else {
+            fatalError("MessagesDataSource has not been set.")
+        }
+        let numberOfMessages = messagesDataSource.numberOfMessages(in: messagesCollectionView)
+        return IndexPath(item: 0, section: numberOfMessages)
         
     }
     

--- a/Sources/Controllers/MessagesViewController.swift
+++ b/Sources/Controllers/MessagesViewController.swift
@@ -326,4 +326,20 @@ extension MessagesViewController: TypingIndicatorDisplayDelegate {
         
     }
     
+    public func viewForTypingIndicator() -> UIView {
+        
+        let typingIndicatorLabel = UILabel()
+        typingIndicatorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        typingIndicatorLabel.textColor = UIColor.black
+        typingIndicatorLabel.text = "someone is typing..."
+        return typingIndicatorLabel
+        
+    }
+    
+    public func frameForIndicatorView() -> CGRect {
+        
+        return CGRect(x: 5, y: 5, width: 325.0, height: 30.0)
+        
+    }
+    
 }

--- a/Sources/Layout/MessagesCollectionViewFlowLayout.swift
+++ b/Sources/Layout/MessagesCollectionViewFlowLayout.swift
@@ -34,6 +34,9 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
             emojiLabelFont = messageLabelFont.withSize(2 * messageLabelFont.pointSize)
         }
     }
+    
+    open var typingIndicatorFont: UIFont
+    
     private var emojiLabelFont: UIFont
 
     open var avatarAlwaysLeading: Bool {
@@ -71,7 +74,8 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         messageLabelFont = UIFont.preferredFont(forTextStyle: .body)
         emojiLabelFont = messageLabelFont.withSize(2 * messageLabelFont.pointSize)
-
+        typingIndicatorFont = UIFont.preferredFont(forTextStyle: .subheadline)
+        
         avatarAlwaysLeading = false
         avatarAlwaysTrailing = false
 
@@ -117,8 +121,12 @@ open class MessagesCollectionViewFlowLayout: UICollectionViewFlowLayout {
 
         guard let messagesCollectionView = messagesCollectionView else { return }
         guard let dataSource = messagesCollectionView.messagesDataSource else { return }
-
         let indexPath = attributes.indexPath
+        if indexPath.section == dataSource.numberOfMessages(in: messagesCollectionView) {
+            guard let indicatorDelegate = messagesCollectionView.typingIndicatorDelegate else { return }
+            attributes.typingIndicatorFrame = indicatorDelegate.frameForIndicatorView()
+            return
+        }
         let message = dataSource.messageForItem(at: indexPath, in: messagesCollectionView)
         let messagePadding = messageContainerPadding(for: message, at: indexPath)
         let messageInsets = messageLabelInsets(for: message, at: indexPath)

--- a/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
+++ b/Sources/Layout/MessagesCollectionViewLayoutAttributes.swift
@@ -41,6 +41,8 @@ final class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttrib
 
     var cellBottomLabelFrame: CGRect = .zero
     var cellBottomLabelInsets: UIEdgeInsets = .zero
+    
+    var typingIndicatorFrame: CGRect = .zero
 
     // MARK: - Methods
 
@@ -56,6 +58,8 @@ final class MessagesCollectionViewLayoutAttributes: UICollectionViewLayoutAttrib
         copy.cellTopLabelInsets = cellTopLabelInsets
         copy.cellBottomLabelFrame = cellBottomLabelFrame
         copy.cellBottomLabelInsets = cellBottomLabelInsets
+        copy.typingIndicatorFrame = typingIndicatorFrame
+
         return copy
         // swiftlint:enable force_cast
     }

--- a/Sources/MessageCollectionViewCell.swift
+++ b/Sources/MessageCollectionViewCell.swift
@@ -133,8 +133,13 @@ open class MessageCollectionViewCell<ContentView: UIView>: UICollectionViewCell 
             let avatar = dataSource.avatar(for: message, at: indexPath, in: messagesCollectionView)
             let topLabelText = dataSource.cellTopLabelAttributedText(for: message, at: indexPath)
             let bottomLabelText = dataSource.cellBottomLabelAttributedText(for: message, at: indexPath)
-
-            avatarView.set(avatar: avatar)
+            
+            if let configureAvatar = dataSource.configureAvatarView(avatarView, for: message, at: indexPath, in: messagesCollectionView) {
+                configureAvatar()
+            } else {
+                avatarView.set(avatar: avatar)
+            }
+            
             cellTopLabel.attributedText = topLabelText
             cellBottomLabel.attributedText = bottomLabelText
         }

--- a/Sources/MessagesDataSource.swift
+++ b/Sources/MessagesDataSource.swift
@@ -39,7 +39,9 @@ public protocol MessagesDataSource: class {
     func cellTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
 
     func cellBottomLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString?
-
+    
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> (() -> Void)?
+    
 }
 
 public extension MessagesDataSource {
@@ -60,4 +62,7 @@ public extension MessagesDataSource {
         return nil
     }
 
+    func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> (() -> Void)? {
+        return nil
+    }
 }

--- a/Sources/Protocols/TypingIndicatorDisplayDelegate.swift
+++ b/Sources/Protocols/TypingIndicatorDisplayDelegate.swift
@@ -1,0 +1,53 @@
+/*
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import Foundation
+
+public protocol TypingIndicatorDisplayDelegate : class {
+    
+    func viewForTypingIndicator() -> UIView
+    
+    func frameForIndicatorView() -> CGRect
+    
+}
+
+public extension TypingIndicatorDisplayDelegate {
+    
+    func viewForTypingIndicator() -> UIView {
+        
+        let typingIndicatorLabel = UILabel()
+        typingIndicatorLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+        typingIndicatorLabel.textColor = UIColor.black
+        typingIndicatorLabel.text = "someone is typing..."
+        return typingIndicatorLabel
+        
+    }
+    
+    func frameForIndicatorView() -> CGRect {
+        
+        return CGRect(x: 5, y: 5, width: 325.0, height: 30.0)
+        
+    }
+    
+}

--- a/Sources/Views/Cells/TypingIndicatorCell.swift
+++ b/Sources/Views/Cells/TypingIndicatorCell.swift
@@ -1,0 +1,67 @@
+/*
+ MIT License
+ 
+ Copyright (c) 2017 MessageKit
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import UIKit
+
+open class TypingIndicatorCell: UICollectionViewCell, CollectionViewReusable {
+    open class func reuseIdentifier() -> String { return "messagekit.cell.typing-indicator" }
+    
+    // MARK: - Properties
+    
+    open var indicatorView = UIView()
+    
+    // MARK: - Initializer
+    
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupSubviews()
+        contentView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    open override func apply(_ layoutAttributes: UICollectionViewLayoutAttributes) {
+        super.apply(layoutAttributes)
+        
+        guard let attributes = layoutAttributes as? MessagesCollectionViewLayoutAttributes else { return }
+        
+        indicatorView.frame = attributes.typingIndicatorFrame
+    }
+    
+    // MARK: - Methods
+    
+    internal func setupSubviews() {
+        contentView.addSubview(indicatorView)
+    }
+    
+    open func configure(in collectionView: MessagesCollectionView) {
+        guard let indicatorDelegate = collectionView.typingIndicatorDelegate else { return }
+        indicatorView = indicatorDelegate.viewForTypingIndicator()
+        indicatorView.frame = indicatorDelegate.frameForIndicatorView()
+        setupSubviews()
+    }
+    
+}

--- a/Sources/Views/MessageLabel.swift
+++ b/Sources/Views/MessageLabel.swift
@@ -406,9 +406,9 @@ open class MessageLabel: UILabel, UIGestureRecognizerDelegate {
         addGestureRecognizer(tapGesture)
         tapGesture.delegate = self
 
-        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
-        addGestureRecognizer(longPressGesture)
-        tapGesture.delegate = self
+//        let longPressGesture = UILongPressGestureRecognizer(target: self, action: #selector(handleGesture(_:)))
+//        addGestureRecognizer(longPressGesture)
+//        longPressGesture.delegate = self
 
         isUserInteractionEnabled = true
     }

--- a/Sources/Views/MessagesCollectionView.swift
+++ b/Sources/Views/MessagesCollectionView.swift
@@ -35,6 +35,8 @@ open class MessagesCollectionView: UICollectionView {
     open weak var messagesLayoutDelegate: MessagesLayoutDelegate?
 
     open weak var messageCellDelegate: MessageCellDelegate?
+    
+    open weak var typingIndicatorDelegate: TypingIndicatorDisplayDelegate?
 
     open var showsDateHeaderAfterTimeInterval: TimeInterval = 3600
 


### PR DESCRIPTION
(Thanks for sending a pull request! Please make sure you click the link above to view the contribution guidelines, then fill out the blanks below.)

What does this implement/fix? Explain your changes.
---------------------------------------------------
Implements support for a typing indicator via a cell added as the last item in the collectionview. Triggered via an observer on the showTypingIndicator property

Does this close any currently open issues?
------------------------------------------



Any relevant logs, error output, etc?
-------------------------------------
-

Any other comments?
-------------------
…

Where has this been tested?
---------------------------
**Devices/Simulators:** iPhone 6 and 6 simulator

**iOS Version:** 10, 11

**Swift Version:** 4

**MessageKit Version:** .9


